### PR TITLE
Re-enable disabled code for 5.9 transition (#40)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+unity8 (8.17+ubports2) xenial; urgency=medium
+
+  * Fix for https://github.com/ubports/ubuntu-touch/issues/624
+
+ -- Dalton Durst <dalton@ubports.com>  Fri, 1 Jun 2018 16:14:11 -0500
+
 unity8 (8.17+ubports1) UNRELEASED; urgency=medium
 
   * No change rebuild to generate sources in ubports repo

--- a/plugins/Dash/listviewwithpageheader.cpp
+++ b/plugins/Dash/listviewwithpageheader.cpp
@@ -1141,11 +1141,10 @@ void ListViewWithPageHeader::contentYAnimationRunningChanged(bool running)
     }
 }
 
-/*
-void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry)
+void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, QQuickGeometryChange change, const QRectF &oldGeometry)
 {
-    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
-    if (heightDiff != 0) {
+    if (change.heightChange()) {
+        const qreal heightDiff = height() - oldGeometry.height();
         if (!m_visibleItems.isEmpty()) {
             ListItem *firstItem = m_visibleItems.first();
             const auto prevFirstItemY = firstItem->y();
@@ -1166,7 +1165,6 @@ void ListViewWithPageHeader::itemGeometryChanged(QQuickItem *item, const QRectF 
         m_contentHeightDirty = true;
     }
 }
-*/
 
 void ListViewWithPageHeader::itemImplicitHeightChanged(QQuickItem *item)
 {

--- a/plugins/Dash/listviewwithpageheader.h
+++ b/plugins/Dash/listviewwithpageheader.h
@@ -116,7 +116,7 @@ protected:
     void viewportMoved(Qt::Orientations orient) override;
     qreal minYExtent() const override;
     qreal maxYExtent() const override;
-    //void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void itemGeometryChanged(QQuickItem *item, QQuickGeometryChange change, const QRectF &oldGeometry) override;
     void itemImplicitHeightChanged(QQuickItem *item) override;
     void updatePolish() override;
 

--- a/plugins/Dash/verticaljournal.cpp
+++ b/plugins/Dash/verticaljournal.cpp
@@ -271,11 +271,9 @@ void VerticalJournal::processModelRemoves(const QVector<QQmlChangeSet::Change> &
     }
 }
 
-
-//void VerticalJournal::itemGeometryChanged(QQuickItem * /*item*/, const QRectF &newGeometry, const QRectF &oldGeometry)
-//{
-//    const qreal heightDiff = newGeometry.height() - oldGeometry.height();
-//    if (heightDiff != 0) {
-//        relayout();
-//    }
-//}
+void VerticalJournal::itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &)
+{
+    if (change.verticalChange()) {
+        relayout();
+    }
+}

--- a/plugins/Dash/verticaljournal.h
+++ b/plugins/Dash/verticaljournal.h
@@ -66,7 +66,7 @@ public:
     void setColumnWidth(qreal columnWidth);
 
 protected:
-//    void itemGeometryChanged(QQuickItem *item, const QRectF &newGeometry, const QRectF &oldGeometry) override;
+    void itemGeometryChanged(QQuickItem * /*item*/, QQuickGeometryChange change, const QRectF &oldGeometry) override;
 
 Q_SIGNALS:
     void columnWidthChanged();

--- a/tests/plugins/CMakeLists.txt
+++ b/tests/plugins/CMakeLists.txt
@@ -8,5 +8,5 @@ add_subdirectory(LightDM)
 add_subdirectory(SessionBroadcast)
 add_subdirectory(Ubuntu)
 add_subdirectory(Unity)
-#add_subdirectory(Utils) #FIXME broken with qt 5.9
+add_subdirectory(Utils)
 add_subdirectory(Wizard)

--- a/tests/plugins/Ubuntu/CMakeLists.txt
+++ b/tests/plugins/Ubuntu/CMakeLists.txt
@@ -1,1 +1,1 @@
-#add_subdirectory(Gestures) #FIXME broken with qt 5.9
+add_subdirectory(Gestures)

--- a/tests/plugins/Ubuntu/Gestures/GestureTest.cpp
+++ b/tests/plugins/Ubuntu/Gestures/GestureTest.cpp
@@ -107,7 +107,7 @@ void GestureTest::sendTouch(qint64 timestamp, int id, QPointF pos,
     QCoreApplication::sendEvent(m_view, &touchEvent);
 
     QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
-    windowPrivate->flushDelayedTouchEvent();
+    windowPrivate->flushFrameSynchronousEvents();
 }
 
 void GestureTest::passTime(qint64 timeSpanMs)

--- a/tests/plugins/Ubuntu/Gestures/tst_TouchGate.cpp
+++ b/tests/plugins/Ubuntu/Gestures/tst_TouchGate.cpp
@@ -189,7 +189,7 @@ void tst_TouchGate::holdsEventsUntilGainsOwnership()
     if (!ownershipAfterTouchEnd) {
         touchRegistry->removeCandidateOwnerForTouch(0, candidateItem);
         QQuickWindowPrivate *wp = QQuickWindowPrivate::get(testItem->window());
-        wp->flushDelayedTouchEvent();
+        wp->flushFrameSynchronousEvents();
         // TouchGate should now open its flood gates and let testItem get all
         // events from touch 0 produced so far
         QCOMPARE(testItem->touchEventsReceived.count(), 2);

--- a/tests/plugins/Utils/ModelTest.cpp
+++ b/tests/plugins/Utils/ModelTest.cpp
@@ -441,7 +441,7 @@ void ModelTest::data()
     QVariant textAlignmentVariant = model->data ( model->index ( 0, 0 ), Qt::TextAlignmentRole );
     if ( textAlignmentVariant.isValid() ) {
         int alignment = textAlignmentVariant.toInt();
-        QCOMPARE( alignment, ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ) );
+        QCOMPARE( alignment, (int) ( alignment & ( Qt::AlignHorizontal_Mask | Qt::AlignVertical_Mask ) ));
     }
 
     // General Purpose roles that should return a QColor

--- a/tests/qmltests/CMakeLists.txt
+++ b/tests/qmltests/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-#add_subdirectory(Components) #FIXME broken with qt 5.9
+add_subdirectory(Components)
 
 add_unity8_qmltest(. OrientedShell)
 add_unity8_qmltest(. DisabledScreenNotice)

--- a/tests/qmltests/Components/tst_DragHandle.cpp
+++ b/tests/qmltests/Components/tst_DragHandle.cpp
@@ -177,7 +177,7 @@ void tst_DragHandle::flickAndHold(QQuickItem *dragHandle,
     QTest::touchEvent(m_view, m_device).release(0, touchPoint.toPoint());
 
     QQuickWindowPrivate *windowPrivate = QQuickWindowPrivate::get(m_view);
-    windowPrivate->flushDelayedTouchEvent();
+    windowPrivate->flushFrameSynchronousEvents();
 }
 
 void tst_DragHandle::drag(QPointF &touchPoint, const QPointF& direction, qreal distance,
@@ -192,7 +192,7 @@ void tst_DragHandle::drag(QPointF &touchPoint, const QPointF& direction, qreal d
         m_fakeTimeSource->m_msecsSinceReference += timeStep;
         QTest::touchEvent(m_view, m_device).move(0, touchPoint.toPoint());
 
-        windowPrivate->flushDelayedTouchEvent();
+        windowPrivate->flushFrameSynchronousEvents();
     }
 }
 

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,1 +1,1 @@
-#add_subdirectory(modules) #FIXME broken with qt 5.9
+add_subdirectory(modules)

--- a/tests/utils/modules/Unity/Test/TouchEventSequenceWrapper.cpp
+++ b/tests/utils/modules/Unity/Test/TouchEventSequenceWrapper.cpp
@@ -26,16 +26,7 @@ TouchEventSequenceWrapper::TouchEventSequenceWrapper(QTest::QTouchEventSequence 
 
 void TouchEventSequenceWrapper::commit(bool processEvents)
 {
-    // Item might be deleted as a consequence of this event sequence being handled
-    // So store its window beforehand
-    QQuickWindow *window = m_item->window();
-
     m_eventSequence.commit(processEvents);
-
-    if (window) {
-        QQuickWindowPrivate *wp = QQuickWindowPrivate::get(window);
-        wp->flushDelayedTouchEvent();
-    }
 }
 
 void TouchEventSequenceWrapper::move(int touchId, int x, int y)


### PR DESCRIPTION
* Revert "[TMP] Support qt 5.9"

This reverts commit 95d8efbee7f6d3c4ef7f1d091f36d64d2155fd80.

* Update changelog

* Override QQuickGeometryChange instead

* Handle geometry changes using geometryChanged() rather than item"

* Another instance of itemGeometryChanged

* The "A-ha" moment

* Remove use of invalid private member

* Unbreak the things I just broke

* Cast to int

* Update header

* Remove stray semicolon

* Don't be so explicit

* Nitpicking

* Flush touch events using the new private flushFrameSynchronousEvents()